### PR TITLE
add tun device

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,6 +6,7 @@ services:
       VERSION: "11"
     devices:
       - /dev/kvm
+      - /dev/net/tun
     cap_add:
       - NET_ADMIN
     ports:

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -18,7 +18,7 @@ metadata:
     name: windows
 spec:
   containers:
-    - name: windows
+  - name: windows
     image: dockurr/windows
     env:
     - name: VERSION

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -28,6 +28,9 @@ spec:
         - containerPort: 3389
           protocol: UDP
       securityContext:
+        capabilities:
+          add:
+          - NET_ADMIN
         privileged: true
       env:
         - name: VERSION
@@ -43,6 +46,8 @@ spec:
           name: storage
         - mountPath: /dev/kvm
           name: dev-kvm
+        - mountPath: /dev/net/tun
+          name: dev-tun
   volumes:
     - name: storage
       persistentVolumeClaim:
@@ -50,6 +55,10 @@ spec:
     - name: dev-kvm
       hostPath:
         path: /dev/kvm
+    - name: dev-tun
+      hostPath:
+        path: /dev/net/tun
+        type: CharDevice
 ---
 apiVersion: v1
 kind: Service

--- a/kubernetes.yml
+++ b/kubernetes.yml
@@ -1,10 +1,11 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: windows-pvc
 spec:
   accessModes:
-    - ReadWriteOnce
+  - ReadWriteOnce
   resources:
     requests:
       storage: 64Gi
@@ -16,68 +17,61 @@ metadata:
   labels:
     name: windows
 spec:
-  terminationGracePeriodSeconds: 120 # the Kubernetes default is 30 seconds and it may be not enough
   containers:
     - name: windows
-      image: dockurr/windows
-      ports:
-        - containerPort: 8006
-          protocol: TCP
-        - containerPort: 3389
-          protocol: TCP
-        - containerPort: 3389
-          protocol: UDP
-      securityContext:
-        capabilities:
-          add:
-          - NET_ADMIN
-        privileged: true
-      env:
-        - name: VERSION
-          value: "11"
-        - name: RAM_SIZE
-          value: "4G"
-        - name: CPU_CORES
-          value: "2"
-        - name: DISK_SIZE
-          value: "64G"
-      volumeMounts:
-        - mountPath: /storage
-          name: storage
-        - mountPath: /dev/kvm
-          name: dev-kvm
-        - mountPath: /dev/net/tun
-          name: dev-tun
+    image: dockurr/windows
+    env:
+    - name: VERSION
+      value: "11"
+    - name: RAM_SIZE
+      value: "4G"
+    - name: CPU_CORES
+      value: "2"
+    - name: DISK_SIZE
+      value: "64G"
+    ports:
+    - containerPort: 8006
+    - containerPort: 3389
+    - containerPort: 3389
+      protocol: UDP
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+      privileged: true
+    volumeMounts:
+    - mountPath: /storage
+      name: storage
+    - mountPath: /dev/kvm
+      name: dev-kvm
+    - mountPath: /dev/net/tun
+      name: dev-tun
+  terminationGracePeriodSeconds: 120
   volumes:
-    - name: storage
-      persistentVolumeClaim:
-        claimName: windows-pvc
-    - name: dev-kvm
-      hostPath:
-        path: /dev/kvm
-    - name: dev-tun
-      hostPath:
-        path: /dev/net/tun
-        type: CharDevice
+  - name: storage
+    persistentVolumeClaim:
+      claimName: windows-pvc
+  - hostPath:
+      path: /dev/kvm
+    name: dev-kvm
+  - hostPath:
+      path: /dev/net/tun
+      type: CharDevice
+    name: dev-tun
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: windows
 spec:
-  type: NodePort
+  ports:
+  - name: tcp-8006
+    port: 8006
+  - name: tcp-3389
+    port: 3389
+  - name: udp-3389
+    port: 3389
+    protocol: UDP
   selector:
     name: windows
-  ports:
-    - name: tcp-8006
-      protocol: TCP
-      port: 8006
-      targetPort: 8006
-    - name: tcp-3389
-      protocol: TCP
-      port: 3389
-      targetPort: 3389
-    - name: udp-3389
-      protocol: UDP
-      port: 3389
-      targetPort: 3389
+  type: NodePort

--- a/readme.md
+++ b/readme.md
@@ -36,8 +36,8 @@ services:
     environment:
       VERSION: "11"
     devices:
-      - /dev/net/tun:/dev/net/tun
       - /dev/kvm
+      - /dev/net/tun
     cap_add:
       - NET_ADMIN
     ports:
@@ -50,7 +50,7 @@ services:
 Via Docker CLI:
 
 ```bash
-docker run -it --rm -p 8006:8006 --device=/dev/kvm --cap-add NET_ADMIN --stop-timeout 120 dockurr/windows
+docker run -it --rm -p 8006:8006 --device=/dev/kvm --device=/dev/net/tun --cap-add NET_ADMIN --stop-timeout 120 dockurr/windows
 ```
 
 Via Kubernetes:

--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,7 @@ services:
     environment:
       VERSION: "11"
     devices:
+      - /dev/net/tun:/dev/net/tun
       - /dev/kvm
     cap_add:
       - NET_ADMIN


### PR DESCRIPTION
required for `containerd.io 1.7.24`, otherwise Samba can't be used.